### PR TITLE
Улучшена пагинация новостей (вид URL и SEO-настройки)

### DIFF
--- a/config/system/urls.php
+++ b/config/system/urls.php
@@ -5,7 +5,7 @@ return [
     'users/<id>/<username>' => 'user/view',
     'users' => 'user/index',
 
-    'news' => 'post/index',
+    'news/<page:\d+>' => 'post/index',
     'news/<id>/<slug>' => 'post/view',
     'news/<slug>' => 'post/view',
 

--- a/controllers/PostController.php
+++ b/controllers/PostController.php
@@ -14,7 +14,6 @@ use yii\helpers\Markdown;
 use yii\helpers\Url;
 use yii\web\Controller;
 use yii\web\ForbiddenHttpException;
-use yii\web\HttpException;
 use yii\web\NotFoundHttpException;
 
 /**
@@ -62,6 +61,15 @@ class PostController extends Controller
      */
     public function actionIndex()
     {
+        $page = Yii::$app->request->getQueryParam('page');
+
+        if ($page > 1) {
+            $this->view->registerMetaTag([
+                'name' => 'robots',
+                'content' => 'noindex,follow'
+            ]);
+        }
+
         $query = Post::find()
             ->with(['user'])
             ->orderBy('post.created_at DESC');
@@ -76,6 +84,7 @@ class PostController extends Controller
             'query' => $query,
             'pagination' => [
                 'pageSize' => self::PAGE_SIZE,
+                'defaultPageSize' => self::PAGE_SIZE, // Hide "per-page" GET-parameter
             ],
         ]);
 

--- a/views/post/index.php
+++ b/views/post/index.php
@@ -32,6 +32,7 @@ $this->title = \Yii::t('post', 'News') . ' - yiiframework.ru';
     <?= LinkPager::widget([
         'options' => ['class' => 'pagination'],
         'pagination' => $provider->getPagination(),
+        'registerLinkTags' => true,
     ]) ?>
 
 </div>


### PR DESCRIPTION
1. Issue #98: URL пагинации приведён к виду /news/N
2. Добавлена регистрация связующих мета-тэгов для поисковых роботов
3. Для поисковых роботов добавлена опция "noindex,follow", если номер страницы > 1

Сопутствующие исправления:
* удалён лишний импорт HttpException