### PR TITLE
FIX for PR #106: правильные атрибуты внешних ссылок в Cookbook

### DIFF
--- a/controllers/CookbookController.php
+++ b/controllers/CookbookController.php
@@ -35,7 +35,11 @@ class CookbookController extends Controller
         }
 
         $content = file_get_contents($file);
-        $content = HtmlPurifier::process(CookbookMarkdown::process($content, 'gfm-comment'));
+
+        $content = HtmlPurifier::process(CookbookMarkdown::process($content, 'gfm-comment'), [
+            'HTML.Nofollow' => true,
+            'HTML.TargetBlank' => true,
+        ]);
 
         $content = preg_replace_callback(
             '~<p>\s*<img(.*?)src="(.*?)"\s+alt="(.*?)"\s*/>\s*</p>~',


### PR DESCRIPTION
Пропускаем через Purifier:
* target = _blank
* rel = nofollow

Это позволяет открывать ссылки классов/методов кукбука в новом окне и не тратить на них заходы поисковых роботов.