### PR TITLE
Added action site/hooks

### DIFF
--- a/controllers/SiteController.php
+++ b/controllers/SiteController.php
@@ -77,6 +77,10 @@ class SiteController extends Controller
                 'successCallback' => [$this, 'onAuthSuccess'],
                 'successUrl' => Url::toRoute('user/edit'),
             ],
+            'hooks' => [
+                'class' => \app\actions\GitHubHookAction::class,
+                'fileName' => '@app/config/system/versions.php',
+            ]
         ];
     }
 


### PR DESCRIPTION
Fixes for #71 

Чтобы это сработало надо сделать:
В репозитории Yii2 нужно добавить хук:
![image](https://user-images.githubusercontent.com/874234/31574767-d5aceccc-b0de-11e7-8594-d1c32bf5c594.png)
![image](https://user-images.githubusercontent.com/874234/31574757-6dbbd088-b0de-11e7-9033-e9b008a1d8d7.png)

Аналогично сделать хук для Yii1 репозитория, с тем же secret, но с Payload URL должен быть `http://yiiframework.ru/site/hooks&version=yii1`

Затем Secret нужно добавить в параметры - \Yii::$app->params['hook-hub-secret'] на сайте yiiframework.ru

После того как хук срабатывает, отрабатывает `site/hooks` и в файл `'fileName' => '@app/config/system/versions.php',` записываются релизные версии. Нужно разрешить запись в этот файл или настроить fileName на другой, доступный для записи, файл.

